### PR TITLE
Update package.json by including babel-cli, babel-core and babel-preset-es2015 ver 6.24.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,6 +48,8 @@
   },
   "devDependencies": {
     "autoprefixer": "^6.0.3",
+    "babel-cli": "^6.24.0",
+    "babel-core": "^6.24.0",
     "babel-eslint": "^6.0.5",
     "babel-jscs": "^2.0.5",
     "babel-loader": "^6.2.4",
@@ -58,7 +60,7 @@
     "babel-plugin-transform-object-rest-spread": "^6.8.0",
     "babel-polyfill": "^6.9.1",
     "babel-preset-env": "^1.2.2",
-    "babel-preset-es2015": "^6.3.13",
+    "babel-preset-es2015": "^6.24.0",
     "babel-preset-react": "^6.3.13",
     "babel-preset-react-hmre": "^1.1.0",
     "babel-preset-stage-0": "^6.3.13",


### PR DESCRIPTION
closes #107 
Update the package.json file with including babel-cli and babel-core and update the version of babel-preset-es2015 - 6.3.13 to 6.24.0
![err](https://cloud.githubusercontent.com/assets/23191491/24319960/f1ba38d0-1150-11e7-935d-89474a5b980c.png)
